### PR TITLE
Allow configuration of compare-images

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,5 +29,11 @@ jobs:
         run: npm install
       - name: Run tests
         run: npm run test
+      - name: Store snapshots from tests
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: snapshots
+          path: ${{ github.workspace }}/src/__snapshots__/
       - name: Run lint
         run: npm run lint

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "extension": ["ts"],
   "spec": "src/**/*.spec.ts",
-  "require": "ts-node/register"
+  "require": "ts-node/register",
+  "timeout": 10000
 }

--- a/src/compare-images.ts
+++ b/src/compare-images.ts
@@ -9,11 +9,25 @@ export const mkDiffPath = (path: string): string => {
 }
 
 export type CompareImagesOpts = {
+  highlightColor:
+    | 'Red'
+    | 'Green'
+    | 'Blue'
+    | 'Opacity'
+    | 'Matte'
+    | 'Cyan'
+    | 'Magenta'
+    | 'Yellow'
+    | 'Black'
+    | 'Gray'
+  highlightStyle: 'Assign' | 'Threshold' | 'Tint' | 'XOR'
   tolerance: number
   writeDiff: boolean
 }
 
 const defaultOpts: CompareImagesOpts = {
+  highlightColor: 'Yellow',
+  highlightStyle: 'Tint',
   tolerance: 0,
   writeDiff: true,
 }
@@ -23,7 +37,7 @@ export const compareImages = (
   resultImagePath: string,
   opts: Partial<CompareImagesOpts> = {},
 ): Promise<boolean> => {
-  const { tolerance, writeDiff }: CompareImagesOpts = {
+  const { tolerance, writeDiff, highlightColor, highlightStyle }: CompareImagesOpts = {
     ...defaultOpts,
     ...opts,
   }
@@ -44,7 +58,8 @@ export const compareImages = (
 
       const options = {
         file: mkDiffPath(resultImagePath),
-        highlightColor: 'yellow',
+        highlightColor,
+        highlightStyle,
         tolerance,
       }
       gm.compare(expectedImagePath, resultImagePath, options, () => resolve(false))

--- a/src/compare-pdf-to-snapshot.ts
+++ b/src/compare-pdf-to-snapshot.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { existsSync, mkdirSync, unlinkSync } from 'fs'
 import { pdfToImage } from './convert-pdf'
-import { compareImages } from './compare-images'
+import { compareImages, CompareImagesOpts } from './compare-images'
 
 export const snapshotsDirName = '__snapshots__'
 
@@ -15,6 +15,7 @@ export const comparePdfToSnapshot = (
   pdf: string | Buffer,
   snapshotDir: string,
   snapshotName: string,
+  compareImageOpts?: Partial<CompareImagesOpts>,
 ): Promise<boolean> => {
   const dir = join(snapshotDir, snapshotsDirName)
   if (!existsSync(dir)) {
@@ -29,7 +30,7 @@ export const comparePdfToSnapshot = (
 
   const newSnapshotPath = join(dir, snapshotName + '.new.png')
   return pdfToImage(pdf, newSnapshotPath).then(() =>
-    compareImages(newSnapshotPath, snapshotPath).then((areEqual) => {
+    compareImages(newSnapshotPath, snapshotPath, compareImageOpts).then((areEqual) => {
       if (areEqual === true) {
         unlinkSync(newSnapshotPath)
         const diffSnapshotPath = join(dir, snapshotName + '.diff.png')


### PR DESCRIPTION
Changes:
- typo `yellow` in compare-images, must be `Yellow`
- enable configuration of compareImages in comparePdfToSnapshot
- if tests fail in github actions: store snapshots as build artifacts so they can be reviewed later
